### PR TITLE
Update CORS policy to allow localhost:3000

### DIFF
--- a/SEP490_BE/Program.cs
+++ b/SEP490_BE/Program.cs
@@ -61,7 +61,7 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFrontend", policy =>
     {
-        policy.WithOrigins("http://localhost:8080")
+        policy.WithOrigins("http://localhost:3000")
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials(); 


### PR DESCRIPTION
Changed the allowed origin in the CORS policy from http://localhost:8080 to http://localhost:3000 to support frontend requests from the new development port.